### PR TITLE
lnk101: honour the sign bit on ZCON relocations

### DIFF
--- a/src/ap101Utils/addrcon.py
+++ b/src/ap101Utils/addrcon.py
@@ -233,7 +233,8 @@ class ZCon:
 
     # --- Apply relocations ---
 
-    def apply(self, target: Addr, flag_type: int) -> None:
+    def apply(self, target: Addr, flag_type: int,
+              flags: int | None = None) -> None:
         """Apply a ZCON relocation: update HW0 address and/or HW1 sector bits.
 
         flag_type is the RLD flag byte with sign bit masked (flags & 0x7F):
@@ -241,11 +242,19 @@ class ZCon:
           0x50:       data address — write HW0, patch DSR
           0x20:       BSR-only     — patch BSR in HW1 only
           0x40:       DSR-only     — patch DSR in HW1 only
+
+        flags is the unmasked flag byte: bit 7 is the sign (V), meaning HW0
+        holds the absolute value of a negative displacement, to be subtracted
+        rather than added.  Building the AddrCon from flag_type alone dropped
+        the bit, leaving every negative-displacement ZCON 2*displacement too
+        high.  Defaults to flag_type (unsigned) for callers that omit it.
         """
         sector = target.sector
+        if flags is None:
+            flags = flag_type
 
         if flag_type in (RLD_ZCON_CODE, RLD_ZCON_ADDR, RLD_ZCON_DATA):
-            con = AddrCon(flag_type)
+            con = AddrCon(flags)
             self.hw0 = con.apply(self.hw0, target)
 
         if flag_type == RLD_BSR_ONLY:

--- a/src/lnk101/linker.py
+++ b/src/lnk101/linker.py
@@ -1265,7 +1265,10 @@ class Linker:
                     # ZCON relocation: read both halfwords, apply, write back
                     if imageOffset + 3 < len(self.image):
                         zcon = ZCon.from_image(self.image, imageOffset)
-                        zcon.apply(targetAddr, flagType)
+                        # Unmasked flags too: bit 7 is the sign, without
+                        # which a negative displacement is added, not
+                        # subtracted.
+                        zcon.apply(targetAddr, flagType, reloc.flags)
                         zcon.write_to_image(self.image, imageOffset)
                         log.debug(f"  -> {zcon}")
                 else:

--- a/src/lnk101/phaseresolve.py
+++ b/src/lnk101/phaseresolve.py
@@ -127,7 +127,7 @@ def _patchSite(extent, offset, flags, target):
             # (the real LE's behavior, issue #22); clear the marker so the
             # sector-encoding apply does not double-count it.
             zcon.hw0 &= 0x7FFF
-        zcon.apply(target, flagType)
+        zcon.apply(target, flagType, flags)
         zcon.write_to_image(buf, offset)
     else:
         con = AddrCon(flags, length)


### PR DESCRIPTION
*Filed under @rburkey2005's account, but written by Claude Code with Ron's review and approval — noted up front so the style doesn't come as a surprise.*

Bit 7 of an RLD flag byte is the sign (V). When it is set, the value already in the text is the *absolute value* of a negative displacement, and must be subtracted from the resolved address rather than added to it. `AddrCon.apply` implements this, and the YCON/ACON path passes it the whole flag byte.

The ZCON path did not. `linker.py` masks the flags down to the type in order to dispatch (`flags & 0x7F`), and `ZCon.apply` then built its `AddrCon` from that masked value — so `AddrCon.sign` was always `0`. Every ZCON carrying a negative displacement was relocated to `target + disp` instead of `target - disp`, i.e. out by exactly twice the displacement.

`ZCon.apply` now also takes the unmasked flag byte and builds its `AddrCon` from that. It defaults to the masked value, so a caller that does not pass it behaves as before.

## Evidence

Found comparing a HAL/S-FC build against an AP-101S memory dump. Pointers to several COMPOOLs were consistently high by exactly twice the displacement in the corresponding RLD:

```
#PCDB021   CSECT base 0x28212    dump 0x28211 (base-1)     linked 0x28213 (base+1)
#PCANNCO   CSECT base 0x30120    dump 0x300E0 (base-0x40)  linked 0x30160 (base+0x40)
```

Every affected halfword also carried `fcmcmp`'s own `(negative disp.)` annotation, which is printed from `flags & 0x80` — so the sign bit was demonstrably present in the RLD and simply not reaching the arithmetic.

With the fix, six data CSECTs in that configuration go from differing to byte-identical and a seventh improves; nothing that matched before stopped matching.

## Testing

`ctest` is unaffected: the same 176 of 204 fail before and after, with identical failure sets (verified by running the suite on a clean tree, applying the change, and running it again). Those failures are pre-existing in my checkout and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
