### PR TITLE
fcmcmp: add --exceptions, for locations not expected to match

### DIFF
--- a/src/tools/fcmcmp.py
+++ b/src/tools/fcmcmp.py
@@ -226,6 +226,7 @@ def compare(sections, image_a, image_b, max_hw_diffs, addr_to_sym, addr_to_rld,
     checked = 0
     no_data_total = 0
     patched_total = 0
+    ignored_total = 0
     stale_exceptions = []
 
     # Compute column width for aligned '@'
@@ -258,6 +259,7 @@ def compare(sections, image_a, image_b, max_hw_diffs, addr_to_sym, addr_to_rld,
         diff_positions = []
         no_data_here = 0
         patched_here = 0
+        ignored_here = 0
         if a != b:
             for hi in range(size.hw):
                 bo = hi * 2
@@ -283,6 +285,9 @@ def compare(sections, image_a, image_b, max_hw_diffs, addr_to_sym, addr_to_rld,
                         here = addr + Addr(hi * 2)
                         expected = exceptions.get(here.hw)
                         if expected is not None:
+                            if expected[0] is None:
+                                ignored_here += 1
+                                continue
                             if expected[0] == hw_b:
                                 patched_here += 1
                                 continue
@@ -290,10 +295,13 @@ def compare(sections, image_a, image_b, max_hw_diffs, addr_to_sym, addr_to_rld,
                     diff_positions.append((addr + Addr(hi * 2), hw_a, hw_b))
         no_data_total += no_data_here
         patched_total += patched_here
+        ignored_total += ignored_here
 
         notes = []
         if patched_here:
             notes.append(f"{patched_here} patched after build")
+        if ignored_here:
+            notes.append(f"{ignored_here} ignored")
         if no_data_here:
             notes.append(f"{no_data_here} no reference data")
         suffix = f" [{', '.join(notes)}]" if notes else ""
@@ -352,6 +360,11 @@ def compare(sections, image_a, image_b, max_hw_diffs, addr_to_sym, addr_to_rld,
                                     continue
                                 if no_data and vb in no_data:
                                     continue
+                                if exceptions:
+                                    e = exceptions.get((addr + Addr(hi * 2)).hw)
+                                    if e is not None and (e[0] is None
+                                                          or e[0] == vb):
+                                        continue
                                 shifted_diffs.append(
                                     (addr + Addr(hi * 2), va, vb))
                     if shifted_diffs:
@@ -369,6 +382,9 @@ def compare(sections, image_a, image_b, max_hw_diffs, addr_to_sym, addr_to_rld,
     if patched_total:
         print(f"\n{patched_total} halfword(s) are listed as changed after the"
               f" build and were not counted as differing.")
+    if ignored_total:
+        print(f"{ignored_total} halfword(s) are listed as to be ignored, with no"
+              f" claim about their contents.")
     if stale_exceptions:
         print(f"WARNING: {len(stale_exceptions)} exception(s) do not match the"
               f" reference image and were ignored; the file may be stale:")
@@ -395,8 +411,20 @@ def load_exceptions(path):
         38266 001D MISSION_ID
 
     the fields being a halfword address, the value the reference image is
-    expected to hold there, and an optional name.  Both numbers are hex.
-    Returns {address: (value, name)}.
+    expected to hold there, and an optional name.  The address is hex; so is
+    the value, EXCEPT for the special value -1.
+
+    -1 means "ignore this address, no claim about what it holds".  The two
+    cases are different in kind and it is worth keeping them apart.  A value
+    says: this location was changed after the build and here is what it was
+    changed to -- checkable, and checked.  -1 says only: a difference here is
+    expected for a reason recorded elsewhere, and nothing is being asserted
+    about the contents.  Without -1 the only way to express the second case
+    would be to write the reference image's own value into the file, which
+    would "verify" trivially and quietly turn a checkable mechanism into one
+    that can absorb any difference at all.
+
+    Returns {address: (value, name)}, value None for -1.
     """
     exceptions = {}
     with open(path) as f:
@@ -408,9 +436,11 @@ def load_exceptions(path):
             if len(fields) < 2:
                 raise ValueError(f"{path}:{lineno}: expected 'address value [name]'")
             try:
-                address, value = int(fields[0], 16), int(fields[1], 16)
+                address = int(fields[0], 16)
+                value = None if fields[1] == "-1" else int(fields[1], 16)
             except ValueError:
-                raise ValueError(f"{path}:{lineno}: address and value must be hex")
+                raise ValueError(f"{path}:{lineno}: address and value must be "
+                                 f"hex, or the value -1")
             exceptions[address] = (value, fields[2] if len(fields) > 2 else "")
     return exceptions
 
@@ -578,12 +608,15 @@ def main(
         str,
         typer.Option(
             "--exceptions",
-            help="File listing locations known to have been changed after the "
-                 "build (I-LOADs, patches), as 'address value [name]' in hex, "
-                 "one per line. Such halfwords are reported separately rather "
-                 "than as differences, but only where the second image really "
-                 "holds the listed value; a mismatch is warned about and the "
-                 "entry ignored.",
+            help="File listing locations that are not expected to match, as "
+                 "'address value [name]' in hex, one per line. A value says "
+                 "the location was changed after the build (an I-LOAD or "
+                 "patch) and gives what it holds; it is honoured only where "
+                 "the second image really holds that value, and a mismatch is "
+                 "warned about and ignored. A value of -1 instead means "
+                 "'ignore this address, no claim about its contents', for a "
+                 "difference expected on grounds recorded elsewhere. Both are "
+                 "reported separately from differences, and from each other.",
         ),
     ] = "",
     no_data: Annotated[

--- a/src/tools/fcmcmp.py
+++ b/src/tools/fcmcmp.py
@@ -220,9 +220,11 @@ def _print_diffs(diff_positions, max_hw_diffs, pad, addr_to_sym, addr_to_rld):
 
 
 def compare(sections, image_a, image_b, max_hw_diffs, addr_to_sym, addr_to_rld,
-            equiv=None, diff_if_shifted=True, expected_sizes=None):
+            equiv=None, diff_if_shifted=True, expected_sizes=None,
+            no_data=None):
     failures = 0
     checked = 0
+    no_data_total = 0
 
     # Compute column width for aligned '@'
     name_width = max((len(name) for name, _, _ in sections), default=0)
@@ -252,6 +254,7 @@ def compare(sections, image_a, image_b, max_hw_diffs, addr_to_sym, addr_to_rld,
         checked += 1
 
         diff_positions = []
+        no_data_here = 0
         if a != b:
             for hi in range(size.hw):
                 bo = hi * 2
@@ -260,13 +263,22 @@ def compare(sections, image_a, image_b, max_hw_diffs, addr_to_sym, addr_to_rld,
                 if hw_a != hw_b:
                     if equiv and hw_a in equiv and hw_b in equiv:
                         continue
+                    # A reference halfword the source image never actually
+                    # stated a value for.  Not a match and not a difference:
+                    # there is nothing to compare against.  Counted and
+                    # reported separately so it cannot be mistaken for either.
+                    if no_data and hw_b in no_data:
+                        no_data_here += 1
+                        continue
                     diff_positions.append((addr + Addr(hi * 2), hw_a, hw_b))
+        no_data_total += no_data_here
 
+        suffix = f" [{no_data_here} no reference data]" if no_data_here else ""
         if not diff_positions:
-            print(f"  OK:   {padded} @ {addr.x} {size_str}")
+            print(f"  OK:   {padded} @ {addr.x} {size_str}{suffix}")
         else:
             print(
-                f"  FAIL: {padded} @ {addr.x} {size_str}"
+                f"  FAIL: {padded} @ {addr.x} {size_str}{suffix}"
                 f" — {len(diff_positions)} halfwords differ"
             )
 
@@ -315,6 +327,8 @@ def compare(sections, image_a, image_b, max_hw_diffs, addr_to_sym, addr_to_rld,
                             if va != vb:
                                 if equiv and va in equiv and vb in equiv:
                                     continue
+                                if no_data and vb in no_data:
+                                    continue
                                 shifted_diffs.append(
                                     (addr + Addr(hi * 2), va, vb))
                     if shifted_diffs:
@@ -329,6 +343,9 @@ def compare(sections, image_a, image_b, max_hw_diffs, addr_to_sym, addr_to_rld,
 
             failures += 1
 
+    if no_data_total:
+        print(f"\n{no_data_total} halfword(s) had no reference data and were"
+              f" neither matched nor counted as differing.")
     return checked, failures
 
 
@@ -491,6 +508,18 @@ def main(
             help="Group sections by base program name instead of sorting by address",
         ),
     ] = False,
+    no_data: Annotated[
+        str,
+        typer.Option(
+            "--no-data",
+            help="Comma-separated hex halfwords that mean the SECOND image "
+                 "never stated a value here (e.g. C9FB,C6C6, which "
+                 "unlinkMAFGEN2 synthesises from the address for any halfword "
+                 "the MAFGEN listing did not report). Such halfwords are "
+                 "reported separately, neither matched nor counted as "
+                 "differing. Empty (the default) keeps them as differences.",
+        ),
+    ] = "",
     equiv: Annotated[
         str,
         typer.Option(
@@ -621,10 +650,13 @@ def main(
             f"({len(image_a) // 2} vs {len(image_b) // 2} halfwords)"
         )
 
+    no_data_set = frozenset(int(v, 16) for v in no_data.split(",")
+                            if v.strip()) or None
+
     checked, failures = compare(
         sections, image_a, image_b, max_hw_diffs, addr_to_sym, addr_to_rld,
         equiv=equiv_set, diff_if_shifted=diff_if_shifted,
-        expected_sizes=expected_sizes,
+        expected_sizes=expected_sizes, no_data=no_data_set,
     )
 
     # Collect all diffs (no elision) when dumping or when repro needs them

--- a/src/tools/fcmcmp.py
+++ b/src/tools/fcmcmp.py
@@ -221,10 +221,12 @@ def _print_diffs(diff_positions, max_hw_diffs, pad, addr_to_sym, addr_to_rld):
 
 def compare(sections, image_a, image_b, max_hw_diffs, addr_to_sym, addr_to_rld,
             equiv=None, diff_if_shifted=True, expected_sizes=None,
-            no_data=None):
+            no_data=None, exceptions=None):
     failures = 0
     checked = 0
     no_data_total = 0
+    patched_total = 0
+    stale_exceptions = []
 
     # Compute column width for aligned '@'
     name_width = max((len(name) for name, _, _ in sections), default=0)
@@ -255,6 +257,7 @@ def compare(sections, image_a, image_b, max_hw_diffs, addr_to_sym, addr_to_rld,
 
         diff_positions = []
         no_data_here = 0
+        patched_here = 0
         if a != b:
             for hi in range(size.hw):
                 bo = hi * 2
@@ -270,10 +273,30 @@ def compare(sections, image_a, image_b, max_hw_diffs, addr_to_sym, addr_to_rld,
                     if no_data and hw_b in no_data:
                         no_data_here += 1
                         continue
+                    # Known to have been changed after the build.  Honoured
+                    # only where the reference image actually holds the value
+                    # the exceptions file claims: otherwise the file is stale
+                    # or wrong for this image, and suppressing a real
+                    # difference on the strength of it would be worse than the
+                    # noise it removes.
+                    if exceptions:
+                        here = addr + Addr(hi * 2)
+                        expected = exceptions.get(here.hw)
+                        if expected is not None:
+                            if expected[0] == hw_b:
+                                patched_here += 1
+                                continue
+                            stale_exceptions.append((here.hw, expected[0], hw_b))
                     diff_positions.append((addr + Addr(hi * 2), hw_a, hw_b))
         no_data_total += no_data_here
+        patched_total += patched_here
 
-        suffix = f" [{no_data_here} no reference data]" if no_data_here else ""
+        notes = []
+        if patched_here:
+            notes.append(f"{patched_here} patched after build")
+        if no_data_here:
+            notes.append(f"{no_data_here} no reference data")
+        suffix = f" [{', '.join(notes)}]" if notes else ""
         if not diff_positions:
             print(f"  OK:   {padded} @ {addr.x} {size_str}{suffix}")
         else:
@@ -343,10 +366,53 @@ def compare(sections, image_a, image_b, max_hw_diffs, addr_to_sym, addr_to_rld,
 
             failures += 1
 
+    if patched_total:
+        print(f"\n{patched_total} halfword(s) are listed as changed after the"
+              f" build and were not counted as differing.")
+    if stale_exceptions:
+        print(f"WARNING: {len(stale_exceptions)} exception(s) do not match the"
+              f" reference image and were ignored; the file may be stale:")
+        for address, want, got in stale_exceptions[:8]:
+            print(f"    {address:05X}: expected {want:04X}, image has {got:04X}")
     if no_data_total:
         print(f"\n{no_data_total} halfword(s) had no reference data and were"
               f" neither matched nor counted as differing.")
     return checked, failures
+
+
+def load_exceptions(path):
+    """Read a list of locations known to have been changed after the build.
+
+    Some locations in a memory image do not hold what the build put there:
+    I-LOADs and patches are applied afterwards, so no correct compilation or
+    link reproduces them.  Reporting them as differences buries the real ones
+    under a class that has to be explained away every time the report is read.
+
+    One location per line, whitespace separated, '#' beginning a comment:
+
+        # exceptions-SSW.txt
+        0304A 0005 CDUV_NSP_VEHICLE_ILOAD
+        38266 001D MISSION_ID
+
+    the fields being a halfword address, the value the reference image is
+    expected to hold there, and an optional name.  Both numbers are hex.
+    Returns {address: (value, name)}.
+    """
+    exceptions = {}
+    with open(path) as f:
+        for lineno, line in enumerate(f, 1):
+            line = line.split("#", 1)[0].strip()
+            if not line:
+                continue
+            fields = line.split()
+            if len(fields) < 2:
+                raise ValueError(f"{path}:{lineno}: expected 'address value [name]'")
+            try:
+                address, value = int(fields[0], 16), int(fields[1], 16)
+            except ValueError:
+                raise ValueError(f"{path}:{lineno}: address and value must be hex")
+            exceptions[address] = (value, fields[2] if len(fields) > 2 else "")
+    return exceptions
 
 
 def collect_diffs(sections, image_a, image_b, equiv=None):
@@ -508,6 +574,18 @@ def main(
             help="Group sections by base program name instead of sorting by address",
         ),
     ] = False,
+    exceptions: Annotated[
+        str,
+        typer.Option(
+            "--exceptions",
+            help="File listing locations known to have been changed after the "
+                 "build (I-LOADs, patches), as 'address value [name]' in hex, "
+                 "one per line. Such halfwords are reported separately rather "
+                 "than as differences, but only where the second image really "
+                 "holds the listed value; a mismatch is warned about and the "
+                 "entry ignored.",
+        ),
+    ] = "",
     no_data: Annotated[
         str,
         typer.Option(
@@ -652,11 +730,15 @@ def main(
 
     no_data_set = frozenset(int(v, 16) for v in no_data.split(",")
                             if v.strip()) or None
+    exceptions_map = load_exceptions(exceptions) if exceptions else None
+    if exceptions_map:
+        print(f"Loaded {len(exceptions_map)} exception(s) from {exceptions}")
 
     checked, failures = compare(
         sections, image_a, image_b, max_hw_diffs, addr_to_sym, addr_to_rld,
         equiv=equiv_set, diff_if_shifted=diff_if_shifted,
         expected_sizes=expected_sizes, no_data=no_data_set,
+        exceptions=exceptions_map,
     )
 
     # Collect all diffs (no elision) when dumping or when repro needs them


### PR DESCRIPTION
*Filed under @rburkey2005's account, but written by Claude Code with Ron's review and approval — noted up front so the style doesn't come as a surprise.*

Stacked on #28 (`--no-data`), which it shares code with. Review that one first.

Not every location in a memory image is expected to match a freshly built one. I-LOADs, patches and checksums are written after the build, and some differences are expected for reasons established elsewhere. Reporting them all as differences buries the real ones under classes that have to be explained away every time someone reads the report.

`--exceptions FILE` names a list of such locations, one per line as `address value [name]` in hex, `#` beginning a comment. **The value has two forms, and the distinction is the point of the feature.**

**A value asserts what the location holds**, and is checked:

```
0304A 0005 CDUV_NSP_VEHICLE_ILOAD
38266 001D MISSION_ID
```

These are honoured **only where the second image really holds that value**. A mismatch is warned about and the entry ignored, so a stale or wrong file cannot quietly suppress a genuine difference.

**`-1` asserts nothing at all** — it means "ignore this address, no claim about its contents":

```
03944 -1 CZ3COM-revised-AK-to-AT
```

That form exists because some differences cannot honestly be stated the first way. Where a difference is expected for a reason recorded outside the file, but nothing is known about what the location *should* contain, the only alternative would be to write the reference image's own value into the file — which would "verify" trivially and would quietly turn a checkable mechanism into one that can absorb any difference at all.

The two are counted and reported separately, and separately from differences:

```
  OK:   #PCDULNK @ 02FFE (193 halfwords) [1 patched after build]
  OK:   #PCZ3COM @ 03918 (55 halfwords) [9 ignored]
```

with totals at the end. A section can therefore be reported `OK` while still carrying halfwords nobody has evidence about, and the counts are always visible.

The option defaults to empty; omitting it restores the previous behaviour exactly.

Found while validating HAL/S-FC compilation and linking against AP-101S memory dumps. There, the checked form covers I-LOADs, patches and checksums — the disassembly listing marks those locations itself — and the `-1` form covers a handful of compilation units that a later release of the flight software revised, where the difference is attributable but its content is not predictable.

`ctest` is unaffected: the same 176 of 204 fail before and after, with identical failure sets. Those failures are pre-existing in my checkout and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
