### PR TITLE
lnk101: leave relocations to sections absent from the CSECT table unpatched

### DIFF
--- a/src/lnk101/linker.py
+++ b/src/lnk101/linker.py
@@ -1240,7 +1240,21 @@ class Linker:
                 #     the IBM linker still sets bit 15 of HW0.
                 #     HW1 (BSR/DSR) is left untouched since RF is unknown.
                 #   YCON / ACON / BSR-only / DSR-only: TXT untouched.
-                if not resolved:
+                # A section the CSECT table does not name is not part of the
+                # configuration that table describes, so the build being
+                # reproduced had nothing to resolve the reference against and
+                # left it alone.  We would otherwise place the section at
+                # whatever address came next and patch a fabricated value,
+                # which cannot match the image the table came from.  Treat it
+                # exactly as an unresolved reference, which is what it is.
+                # Truthiness, not "is not None": csectTable defaults to {}, so
+                # a link with no table would otherwise find every section
+                # absent.
+                absent = (bool(self.csectTable)
+                          and targetSection is not None
+                          and targetSection.name.strip() not in self.csectTable)
+
+                if not resolved or absent:
                     flagType = reloc.flags & 0x7F
                     if flagType in (RLD_ZCON_CODE, RLD_ZCON_ADDR, RLD_ZCON_DATA) \
                             and imageOffset < len(self.image):


### PR DESCRIPTION
*Filed under @rburkey2005's account, but written by Claude Code with Ron's review and approval — noted up front so the style doesn't come as a surprise.*

With `--external-syms`, the CSECT table describes one memory configuration. A section the table does not name is not in that configuration, so the build being reproduced had nothing to resolve a reference to it against, and left the reference alone. We instead place the section at whatever address comes next and patch a fabricated value — which cannot match the image the table came from.

This showed up on seven units whose only presence in a configuration is their ZCON. The ZCON carries a `0x10` (ZCON/addr) relocation to the unit's own code section, which lives in another overlay. The dump holds:

```
8000 0E00        HW0 bit 15 set, BSR unpatched
```

and we produced `8000 0E20` — BSR 2 being the sector of the `0x10000` fallback address. All 32 of that configuration's ZCONs in this situation hold exactly `8000 0E00`, so the unpatched form is what the linker really produced.

Worth noting that HW0 matched only by luck: `0x10000` is sector-aligned, so `8000 | (0x10000 & 0x7FFF)` came out `8000` regardless. A fallback address that wasn't sector-aligned would have corrupted both halfwords.

The existing unresolved-RLD path (issue #22) already does exactly the right thing here, so an absent target now takes it: bit 15 of HW0 for the ZCON address types, TXT untouched otherwise.

**Scope and how to disable.** The check is gated on a CSECT table actually being loaded, so without `--external-syms` nothing changes at all. It tests `bool(self.csectTable)` rather than `is not None`, because `csectTable` defaults to `{}` — testing for None would have found every section absent on links that pass no table.

**Verification.**
- The seven units now produce `8000 0E00` exactly, matching the dump.
- Every in-index section across those seven compares clean — 0 failures, where previously the link failed outright and nothing was compared at all.
- Twelve modules from a configuration that already matched 509/509 still match, so no regression.

Found while validating HAL/S-FC compilation and linking against AP-101S memory dumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
