### PR TITLE
fcmcmp: report N/A for a difference against another section's memory

### DIFF
--- a/src/tools/extract_fcmcmp_diffs.py
+++ b/src/tools/extract_fcmcmp_diffs.py
@@ -23,7 +23,11 @@ def extract_diffs(text):
             current_section = m.group(1)
             continue
 
-        if stripped.startswith('OK:') or stripped.startswith('SKIP:'):
+        # "N/A:" closes a section as surely as OK: does.  It is emitted for a
+        # section that differs but is not in the configuration, so no diff lines
+        # follow it; without it here, a preceding FAIL would stay current and the
+        # next stray "@ addr" line would be filed under the wrong section.
+        if stripped.startswith(('OK:', 'SKIP:', 'N/A:')):
             current_section = None
             continue
 

--- a/src/tools/fcmcmp.py
+++ b/src/tools/fcmcmp.py
@@ -97,6 +97,44 @@ def load_expected_sizes(csect_table_path):
     return sizes
 
 
+def load_not_in_config(csect_table_path):
+    """Sections the CSECT table says this configuration does not contain, mapped
+    to the section that owns their span instead.
+
+    A CSECT table may deliberately carry sections the configuration does not
+    contain.  The linker needs their addresses: a configuration can hold a
+    module's ZCON without holding the module, and the ZCON must point at the
+    address that code has in the configuration where the overlay IS loaded.  So
+    the section gets placed, and is then compared against whatever the reference
+    image happens to hold there -- unrelated memory.  The resulting
+    "differences" are not differences; the comparison was never meaningful.  In
+    G3, DKFCM2 reported "FAIL: 2/3 section(s) differ" with 14 and 61 differing
+    halfwords, and neither section is in G3 at all.
+
+    The value carries "spanOwner": the name of a different section, in this
+    configuration's own index, covering the same address.  It is required, not
+    decorative, and the reason is that "inConfig": false is weak evidence.  A
+    configuration can hold both the ZCON and the module, so a section marked
+    absent may be present after all.  Measured across eight PASS
+    configurations, 79 marked sections MATCH the reference image, and 59 of them
+    verify content that the --no-data patterns do not account for -- up to 477
+    halfwords, in SSW's #DDCDDG3.  Those are real agreements about real memory.
+
+    So a mark alone is never allowed to suppress anything.  A spanOwner says
+    what the memory demonstrably belongs to instead, and only then is a
+    difference known to be meaningless.  In G3, 0xB728 lies inside #PCGZFLD; in
+    SSW that same address is unclaimed, and there #DDKFCM2 matches.
+
+    Nothing is inferred.  An entry without the field is in-configuration, so a
+    table that does not use it behaves exactly as before.
+    """
+    with open(csect_table_path) as f:
+        data = json.load(f)
+    return {name: info.get("spanOwner")
+            for name, info in data.items()
+            if isinstance(info, dict) and info.get("inConfig") is False}
+
+
 def _format_size(size_hw, expected_hw):
     """Return '(N halfwords)' or '(N halfwords vs M expected)' if mismatched."""
     if expected_hw is not None and expected_hw != size_hw:
@@ -223,10 +261,12 @@ def _print_diffs(diff_positions, max_hw_diffs, pad, addr_to_sym, addr_to_rld):
 
 def compare(sections, image_a, image_b, max_hw_diffs, addr_to_sym, addr_to_rld,
             equiv=None, diff_if_shifted=True, expected_sizes=None,
+            not_in_config=None,
             no_data=None, exceptions=None, exception_kinds=None):
     failures = 0
     checked = 0
     size_mismatches = []
+    skipped = []
     no_data_total = 0
     patched_total = 0
     ignored_total = 0
@@ -316,6 +356,36 @@ def compare(sections, image_a, image_b, max_hw_diffs, addr_to_sym, addr_to_rld,
         suffix = f" [{', '.join(notes)}]" if notes else ""
         if not diff_positions:
             print(f"  OK:   {padded} @ {addr.x} {size_str}{suffix}")
+        elif not_in_config and not_in_config.get(name.strip()):
+            # This section is not in the configuration, and another section in
+            # the configuration's own index owns the span, so the halfwords just
+            # compared belong to that one.  A difference against it says nothing.
+            #
+            # The order of these branches is the safety property, not a matter of
+            # style.  The test comes AFTER the comparison and after the
+            # no-difference case, so a section marked absent that nevertheless
+            # MATCHES is still reported as OK.  It has to be: the mark says where
+            # an address came from, not that the section is gone.  Skipping on the
+            # mark alone was tried first, and on the eight PASS configurations it
+            # silenced 36 sections that match -- 28 of them verifying content the
+            # --no-data patterns do not cover, 296 halfwords in all.  Hiding
+            # agreement is a worse fault than the noise this removes.
+            #
+            # Downgrading only a failure, and only where the span has a named
+            # owner, cannot lose a match however wrong the mark is.
+            #
+            # "N/A:" and not a word of its own, for two reasons.  It occupies the
+            # same 8-column field as "OK:" and "FAIL:", so the section names stay
+            # in one column down the whole report; and it does not read as an
+            # alarm.  A failure count is the first thing anyone looks at here, and
+            # a non-zero one is disturbing whether or not it means anything.
+            print(f"  N/A:  {padded} @ {addr.x} {size_str}{suffix}"
+                  f" — not in this configuration;"
+                  f" this span belongs to {not_in_config[name.strip()]}")
+            skipped.append(name.strip())
+            # Not counted among the sections checked: the run makes no claim
+            # about it, so it must not swell a "PASS: all N sections match".
+            checked -= 1
         else:
             print(
                 f"  FAIL: {padded} @ {addr.x} {size_str}{suffix}"
@@ -406,7 +476,7 @@ def compare(sections, image_a, image_b, max_hw_diffs, addr_to_sym, addr_to_rld,
     if no_data_total:
         print(f"\n{no_data_total} halfword(s) had no reference data and were"
               f" neither matched nor counted as differing.")
-    return checked, failures, size_mismatches
+    return checked, failures, size_mismatches, skipped
 
 
 # "# -1 = Probable version-change related difference", declaring what a marker
@@ -757,6 +827,7 @@ def main(
 
     addr_to_sym, addr_to_rld = load_annotations(sym_json, csect_table)
     expected_sizes = load_expected_sizes(csect_table) if csect_table else None
+    not_in_config = load_not_in_config(csect_table) if csect_table else None
 
     # --diff-json mode: compare FCM_A against recorded reference values
     if diff_json:
@@ -806,11 +877,12 @@ def main(
     if exceptions_map:
         print(f"Loaded {len(exceptions_map)} exception(s) from {exceptions}")
 
-    checked, failures, size_mismatches = compare(
+    checked, failures, size_mismatches, skipped = compare(
         sections, image_a, image_b, max_hw_diffs, addr_to_sym, addr_to_rld,
         equiv=equiv_set, diff_if_shifted=diff_if_shifted,
         expected_sizes=expected_sizes, no_data=no_data_set,
         exceptions=exceptions_map, exception_kinds=exception_kinds,
+        not_in_config=not_in_config,
     )
 
     # Collect all diffs (no elision) when dumping or when repro needs them
@@ -853,6 +925,10 @@ def main(
         raise typer.Exit(1)
     else:
         print(f"\nPASS: all {checked} sections match")
+    if skipped:
+        print(f"{len(skipped)} section(s) differ but are not in this "
+              f"configuration, so the difference is against memory belonging to "
+              f"another section and no claim is made: {', '.join(skipped)}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

*Note: none of this shows up unless you pass `--csect-table` an
`augmented-<CFG>.json` rather than a `csects-<CFG>.json`. The `csects-` tables
are the raw MAFGEN scrape and do not carry the two fields this depends on, so
with them fcmcmp behaves exactly as it does today. The augmented tables are
published alongside them in the Virtual AGC project, at
`PFS/mafgen/augmented-<CFG>.json`; nothing else about the command changes. See
"Compatibility" below.*

## The problem

A CSECT table can carry sections the configuration does not contain. The linker
needs their addresses: a configuration can hold a module's ZCON without holding
the module, and the ZCON has to point at the address that code occupies in the
configuration that *does* load the overlay. So the section gets placed, and is
then compared against whatever the reference image happens to hold at that
address — unrelated memory. The differences that come out are not differences.

In PASS configuration G3, the DKFCM2 report reads

```
  OK:   #ZDKFCM2 @ 00236 (2 halfwords)
  FAIL: #DDKFCM2 @ 0B728 (15 halfwords) — 14 halfwords differ
  FAIL: #CDKFCM2 @ 1E68C (61 halfwords) — 61 halfwords differ
FAIL: 2/3 section(s) differ
```

while the corpus score for G3 is a clean 2905/2905. Both are correct: neither
`#DDKFCM2` nor `#CDKFCM2` is in G3, only their ZCON is, and the scoring already
excluded them. But it means anyone auditing the reports finds failures the
headline number denies, and nothing in the report distinguishes a meaningless
difference from a real one.

## The change

A producer marks such a section with two fields:

| field | meaning |
|---|---|
| `"inConfig": false` | which pass recovered the *address*. Weak evidence; not proof of absence. |
| `"spanOwner"` | the name of a **different** section, in this configuration's own index, that covers the same address. |

Where a difference is found and both fields are present, the report becomes

```
  OK:   #ZDKFCM2 @ 00236 (2 halfwords)
  N/A:  #DDKFCM2 @ 0B728 (15 halfwords) — not in this configuration; this span belongs to #PCGZFLD
  N/A:  #CDKFCM2 @ 1E68C (61 halfwords) — not in this configuration; this span belongs to #CDCDDG3
PASS: all 1 sections match
2 section(s) differ but are not in this configuration, so the difference is against
memory belonging to another section and no claim is made: #DDKFCM2, #CDKFCM2
```

The section is left out of the checked total, so it can neither fail nor pad a
`PASS: all N sections match`.

`N/A:` rather than a word of its own: it occupies the same 8-column field as
`OK:` and `FAIL:`, so section names stay in one column down the whole report,
and it does not read as an alarm. A failure count is the first thing anyone
looks at in one of these, and a non-zero one is disturbing whether or not it
turns out to mean anything.

`extract_fcmcmp_diffs.py` closes the current section on `N/A:` as it already
does on `OK:` and `SKIP:`. No diff lines follow an `N/A:` line, so without that
a preceding `FAIL` would stay current and a later stray `@ addr` line would be
filed under the wrong section.

## Why the span owner is required, and why the test order matters

I got this wrong twice, and both failures are worth recording because they point
in opposite directions.

**Marking by absence from the index hides sections that are present.** `#PCDHMMU`
does not appear in the scraped index for its configuration, yet it is genuinely
there — 788 halfwords inside `FCMBMTPG`, with 170 agreeing references.

**Marking by provenance and skipping before the comparison hides agreement.** A
configuration can carry both a module's ZCON *and* the module. Measured over
eight PASS configurations, 79 marked sections **match** the reference image, 59
of them verifying content that `--no-data` does not account for — up to 477
halfwords, in SSW's `#DDCDDG3`. Skipping on the mark would have silenced 36 of
those agreements, 28 with real content behind them.

So the mark alone never suppresses anything. The test runs **after** the
comparison and after the no-difference case, which makes the safety property
structural rather than a matter of getting the evidence right: a marked section
that matches still reports OK, however wrong the mark is. SSW's `#DDKFCM2`
matches, and its span there is unclaimed; in G3 the same address, `0xB728`, lies
inside `#PCGZFLD`. Same section, same address, opposite meanings — which is why
no static property of the name can decide it.

## Verification

All 439 G3 comparisons were re-run with the code held constant and only the
CSECT table varying, which isolates the change exactly:

| transition | count |
|---|---|
| `OK` → `OK` | 2910 |
| `FAIL` → `N/A` | 40 |
| `FAIL` → `FAIL` | 15 |
| unintended | **0** |

Across all eight configurations, every one of the 231 suppressed failures has a
named span owner.

## Compatibility, and what you need to see any of this

Nothing is inferred. An entry without the two fields is treated as
in-configuration, so a CSECT table that does not carry them behaves exactly as
before — no `N/A` lines, same verdicts, same exit status.

That was checked rather than assumed. Running this branch and `master` over the
same inputs, twice — once with no `--csect-table` at all, once with a table
carrying only `start`/`end` — the output is byte-identical apart from the
version banner fcmcmp stamps into every report. A table that sets
`"inConfig": false` but no `spanOwner` also behaves exactly as before, since
both fields are required before anything is suppressed.

**So this will do nothing for you as things stand, and that is worth saying
plainly.** `tools/retest_open_issues.sh` passes `../csects-G9.json` to both
`lnk101 --external-syms` and `fcmcmp --csect-table`, and those tables are the
raw MAFGEN scrape: 1629 entries in `csects-G3.json`, none of them carrying
either field. `lnk101` consumes a CSECT table, it does not produce one, so
nothing in this repository can add them.

The fields are written by `dass-syms.py` in the Virtual AGC project, which has
the MAFGEN dumps and the per-configuration indexes needed to work out that a
section is absent and to name what occupies its span instead.

No workflow change is needed at your end — the same `--csect-table` argument,
pointed at a different file. Augmented tables for all eight configurations are
now published in the Virtual AGC project as

    PFS/mafgen/augmented-<CFG>.json

alongside the unmodified `csects-<CFG>.json` scrape. For your retest script
that is one substitution:

```sh
fcmcmp --csect-table ../augmented-G9.json GV7RTL.json GV7RTL.fcm ../G9.fcm
```

`lnk101 --external-syms` can take either; the augmented table is a superset.

One caution if you ever generate such tables yourself: don't name them
`csects-*.json`. `dass-syms.py` globs that pattern to discover the other
configurations and takes whatever follows the prefix as a configuration name,
so a `csects-G9-augmented.json` becomes a phantom configuration. That is why
the published files are `augmented-<CFG>.json` instead.

Independent of #32 and #33 — one commit on top of `master`, touching
`src/tools/fcmcmp.py` and `src/tools/extract_fcmcmp_diffs.py`.
