### PR TITLE
lnk101: a signed ACON negates its address field, not its opcode byte

### DIFF
--- a/src/ap101Utils/addrcon.py
+++ b/src/ap101Utils/addrcon.py
@@ -130,6 +130,14 @@ class AddrCon:
             return target.sector_encode()
         return target.hw
 
+    # The address field of a 4-byte ACON.  A fullword relocation is also how
+    # the BCE long-format instructions carry their operand -- the opcode is the
+    # top byte and the address the low 24 bits -- because the format has no
+    # relocation of that width: YCON is 2 bytes, ACON is 4, and nothing lies
+    # between.  Adding leaves the opcode alone, so the unsigned case has always
+    # worked; negating the whole word does not.
+    _ACON_ADDRESS = 0x00FFFFFF
+
     def apply(self, existing: int, target: Addr) -> int:
         """Apply this relocation: compute new value from existing and target.
 
@@ -138,16 +146,38 @@ class AddrCon:
         number.  S (direction) is the direction of relocation.  So:
             result = (V==0 ? +existing : -existing)
                    + (S==0 ? +value : -value)
+
+        A SIGNED FULLWORD NEGATES ITS ADDRESS FIELD, NOT ITS TOP BYTE.  The
+        rule above is written for a YCON, where the whole field is the
+        constant.  A 4-byte ACON may carry an opcode in its top byte, and
+        negating that too corrupts the instruction: `#LBR@ FIOBRE-2` assembles
+        FA000002, and with FIOBRE at 8BC6 the whole-word negation gives
+        06008BC4 -- the address right and FA00 destroyed -- where the original
+        build has FA008BC4.  Only the low 24 bits are the constant, so only
+        they are negated.  This changes nothing for a value that fits in 24
+        bits, which every AP-101 address does, so an ordinary signed ACON is
+        unaffected; it changes only the case where the top byte is non-zero,
+        and a displacement of 16M is not one.
         """
         value = self.encode(target)
-        signed_existing = -existing if self.sign else existing
         signed_value = -value if self.direction else value
+        if self.sign and self.length == 4:
+            field = existing & self._ACON_ADDRESS
+            return ((existing & ~self._ACON_ADDRESS)
+                    | ((signed_value - field) & self._ACON_ADDRESS)) & self.mask
+        signed_existing = -existing if self.sign else existing
         return (signed_existing + signed_value) & self.mask
 
     def reverse(self, existing: int, result: int, sector: int = 0) -> int:
         """Reverse this relocation: given existing and result, recover
         the target halfword address.  For sector 1+ ZCONs, pass the
         sector register value to fully decode."""
+        if self.sign and self.length == 4:
+            # The inverse of the address-field form above.
+            signed_value = ((result & self._ACON_ADDRESS)
+                            + (existing & self._ACON_ADDRESS)) \
+                           & self._ACON_ADDRESS
+            return (-signed_value & self.mask) if self.direction else signed_value
         signed_existing = -existing if self.sign else existing
         signed_value = (result - signed_existing) & self.mask
         target_raw = (-signed_value & self.mask) if self.direction else signed_value

--- a/test/srcTest/ap101Utils/test_addrcon.py
+++ b/test/srcTest/ap101Utils/test_addrcon.py
@@ -178,5 +178,57 @@ class TestAddrConReverse(unittest.TestCase):
                 self._roundtrip(sign, direction, 0x0019, 0x448F8)
 
 
+class TestSignedAconAddressField(unittest.TestCase):
+    """A signed 4-byte ACON negates its ADDRESS FIELD, not its top byte.
+
+    The BCE long-format instructions carry their operand in a fullword whose
+    top byte is the opcode and whose low 24 bits are the address, because the
+    format has no relocation of that width -- YCON is 2 bytes, ACON is 4, and
+    nothing lies between.  Adding leaves the opcode alone, so V=0 has always
+    worked; negating the whole word does not.
+
+    FIOMDPPG is the case.  Its contemporary assembly listing gives
+
+        00006 FA00 0002      0002    33    #LBR@ FIOBRE-2
+
+    -- the magnitude, opcode intact -- and DASS_G9 has FA00 8BC4 with FIOBRE
+    at halfword 8BC6.
+    """
+
+    def test_lbr_negative_displacement_keeps_opcode(self):
+        con = AddrCon(0x9C)
+        self.assertEqual(con.length, 4)
+        self.assertEqual(con.sign, 1)
+        self.assertEqual(con.apply(0xFA000002, Addr.from_hw(0x8BC6)),
+                         0xFA008BC4)
+
+    def test_mout_negative_displacement_keeps_opcode(self):
+        con = AddrCon(0x9C)
+        self.assertEqual(con.apply(0xFD000002, Addr.from_hw(0x8C94)),
+                         0xFD008C92)
+
+    def test_unsigned_acon_is_unchanged(self):
+        # V=0 adds, which is how every positive `#LBR@ SYM+n` already links.
+        con = AddrCon(0x1C)
+        self.assertEqual(con.apply(0xFA000002, Addr.from_hw(0x8BC6)),
+                         0xFA008BC8)
+
+    def test_signed_acon_without_an_opcode_byte_is_unchanged(self):
+        # An ordinary signed adcon, top byte zero: identical to whole-word
+        # arithmetic, because every AP-101 address fits in 24 bits.
+        con = AddrCon(0x9C)
+        self.assertEqual(con.apply(0x00000001, Addr.from_hw(0x271A)), 0x2719)
+
+    def test_roundtrip(self):
+        con = AddrCon(0x9C)
+        for existing, target_hw in ((0xFA000002, 0x8BC6),
+                                    (0xFD000002, 0x8C94),
+                                    (0x00000001, 0x271A)):
+            result = con.apply(existing, Addr.from_hw(target_hw))
+            self.assertEqual(con.reverse(existing, result), target_hw,
+                             f"existing=0x{existing:08X} "
+                             f"target=0x{target_hw:05X}")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
*Filed under @rburkey2005's account, but written by Claude Code with Ron's review and approval — noted up front so the style doesn't come as a surprise.*

`AddrCon.apply` implements OBJECTGE.xpl's V flag by negating the whole existing value:

```python
signed_existing = -existing if self.sign else existing
```

That is right for a YCON, where the entire two-byte field is the constant. It is wrong for a four-byte ACON, because the BCE long-format instructions carry their operand in a fullword whose **top byte is the opcode** and whose low 24 bits are the address. The format has no relocation of that width — YCON is 2 bytes, ACON is 4, and nothing lies between — so a fullword ACON is how such an operand has to be relocated. Adding leaves the opcode alone, which is why V=0 has always worked; negating does not.

FIOMDPPG is the case. Its contemporary assembly listing gives

```
00006 FA00 0002      0002    33    #LBR@ FIOBRE-2
```

— the magnitude, opcode intact — and `DASS_G9` has `FA00 8BC4`, with `FIOBRE` at halfword `8BC6`. Whole-word negation produces `0600 8BC4`: the address correct and `FA00` destroyed.

This negates only the low 24 bits and leaves the rest of the word standing. It changes nothing for a value that fits in 24 bits, which every AP-101 address does, so an ordinary signed adcon is unaffected; it changes only the case where the top byte is non-zero, and a displacement of 16M is not one. `reverse()` mirrors it so the round-trip still holds.

Five tests added, covering both FIOMDPPG operands, the unsigned ACON that must be untouched, a signed ACON with no opcode byte, and the round-trip. The existing 18 tests pass unchanged.

The assembler side that exercises this is a separate change in virtualagc's ASM101S: it emits the listing's magnitude with flag `0x9C` instead of dropping the relocation entirely. With the two together, FIOMDPPG's object is byte-identical to its contemporary listing and its section matches the G9 memory dump.
