### PR TITLE
fcmcmp: annotate the halfword that holds the address, not the opcode

### DIFF
--- a/src/tools/fcmcmp.py
+++ b/src/tools/fcmcmp.py
@@ -59,13 +59,27 @@ def load_annotations(sym_json_path, csect_table_path=None):
         addr_to_sym[s["address"]] = s["name"]
 
     for r in sym_data.get("relocations", []):
-        hw_addr = r["address"]
         target = Addr.from_hw(r["target"])
         sym = r.get("symbol", "")
         targetName = r.get("targetName", "")
         flags = r.get("flags", 0)
+        con = AddrCon(flags)
+        # KEY ON THE HALFWORD THAT HOLDS THE ADDRESS, not on the first halfword
+        # of the relocated field.  A 4-byte ACON begins with the opcode
+        # halfword, which is identical however the site resolved, so an
+        # annotation attached there is never printed beside a difference.
+        # OI340600's G9 shows it: FIOPDSPG differs at 1E4B3 and 1E4BF while its
+        # two relocations start at 1E4B2 and 1E4BE, so the two lines that
+        # needed explaining printed bare --
+        #
+        #     @ 1E4B3 05C0 vs 0000
+        #     @ 1E4BF 05C4 vs 0000
+        #
+        # -- while the "RLD TFCMPFD1 -> F20005C0" that explains them sat on a
+        # halfword that always matches and so was never shown.
+        hw_addr = r["address"] + (con.length // 2 - 1)
         label = f"{targetName} ({sym})" if targetName and sym and targetName != sym else (sym or targetName)
-        neg = " (negative disp.)" if AddrCon(flags).is_negative else ""
+        neg = " (negative disp.)" if con.is_negative else ""
         addr_to_rld[hw_addr] = f"RLD {label} -> {target.x}{neg}"
 
     if csect_table_path:

--- a/test/fcmcmp/test_fcmcmp.py
+++ b/test/fcmcmp/test_fcmcmp.py
@@ -248,6 +248,36 @@ def test_extract_fcmcmp_diffs():
     assert all(k in diffs[0] for k in ("section", "address", "hw_a", "hw_b"))
 
 
+def test_rld_annotation_keys_the_halfword_holding_the_address(tmp_path):
+    """A 4-byte ACON's annotation belongs on its SECOND halfword.
+
+    The first is the opcode, which is identical however the site resolved, so
+    an annotation attached there is never printed beside a difference -- which
+    is the only place it is any use.  A 2-byte YCON keeps its own halfword.
+    """
+    import json
+    from tools.fcmcmp import load_annotations
+
+    sym = {
+        "symbols": [],
+        "relocations": [
+            {"address": 0x1E4B2, "target": 0xF20005C0, "flags": 0x1C,
+             "symbol": "TFCMPFD1"},                      # ACON, 4 bytes
+            {"address": 0x02000, "target": 0x000A50, "flags": 0x00,
+             "symbol": "TFIVPS22"},                      # YCON, 2 bytes
+        ],
+    }
+    path = tmp_path / "sym.json"
+    path.write_text(json.dumps(sym))
+    _, addr_to_rld, = load_annotations(path)[:2]
+
+    assert 0x1E4B3 in addr_to_rld, "ACON annotation must sit on the address"
+    assert 0x1E4B2 not in addr_to_rld, "not on the opcode halfword"
+    assert "TFCMPFD1" in addr_to_rld[0x1E4B3]
+    assert 0x02000 in addr_to_rld, "a YCON is one halfword and keeps its own"
+    assert "TFIVPS22" in addr_to_rld[0x02000]
+
+
 if __name__ == "__main__":
     import pytest
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
*Filed under @rburkey2005's account, but written by Claude Code with Ron's review and approval — noted up front so the style doesn't come as a surprise.*

`addr_to_rld` is keyed on a relocation's `address`, which is the first halfword of the relocated field. For a 4-byte ACON that is the **opcode** halfword — and an opcode is identical however the site resolved. So the annotation sits on a halfword that never differs, and is therefore never printed, which is the only place it would have been any use.

OI340600's G9 shows it. `FIOPDSPG`'s two relocations start at `1E4B2` and `1E4BE`, and the differing halfwords are `1E4B3` and `1E4BF`, so the report read

```
@ 1E4B3 05C0 vs 0000
@ 1E4BF 05C4 vs 0000
```

with nothing to say what those addresses were, while the RLD lines naming `TFCMPFD1` and `TFCMPFD2` were attached to `1E4B2` and `1E4BE` and never shown. It now reads

```
@ 1E4B3 05C0 vs 0000  ; RLD TFCMPFD1 -> F20005C0
@ 1E4BF 05C4 vs 0000  ; RLD TFCMPFD2 -> F20005C4
```

`AddrCon` already knows the length, so the key becomes `address + (length // 2 - 1)`: a 2-byte YCON or ZCON keeps its own halfword and only the 4-byte ACON moves. Annotation only — no comparison behaviour changes. Verified across three OI340600 configurations, whose section counts are unchanged at 39/1116, 123/1090 and 33/570.

One test added. `test/fcmcmp/test_fcmcmp.py` goes from 17 passed to 18, with the same single pre-existing failure (`test_csect_table_size_mismatch`) before and after.
