### PR TITLE
lnk101: a CSECT-table entry may supply an address without supplying a definition

### DIFF
--- a/src/lnk101/linker.py
+++ b/src/lnk101/linker.py
@@ -413,6 +413,10 @@ class Linker:
         self.appliedRelocations = []
         self.unresolvedRelocations = []
         self.csectTable = {}
+        # Symbols a CSECT table supplied for PLACEMENT only: defined, so the
+        # symbol table is unchanged, but never used to resolve a relocation.
+        # See the note where the table is loaded.
+        self.placementOnlySymbols = set()
         self.deadERsLogged = set()
         # CON80 NOCALLER (NCAL): unresolved externals are tolerated and left
         # in the image (the linkage editor's automatic-library-call is off).
@@ -1181,7 +1185,16 @@ class Linker:
 
                 elif reloc.relId in module.externals:
                     ext = module.externals[reloc.relId]
-                    if ext.resolved and ext.resolvedSection and ext.resolvedSection.baseAddress is not None:
+                    # A PLACEMENT-ONLY SYMBOL IS DEFINED BUT DOES NOT RESOLVE.
+                    # It names a field of a section this configuration does not
+                    # load, so the original link had no definition either and
+                    # left the site alone; treating it as unresolved reproduces
+                    # that and records it in unresolvedRelocations, where the
+                    # archive gap is already accounted for.
+                    if ext.name in self.placementOnlySymbols:
+                        resolved = False
+                        lenient = True
+                    elif ext.resolved and ext.resolvedSection and ext.resolvedSection.baseAddress is not None:
                         targetAddr = ext.resolvedSection.baseAddress
                     else:
                         resolved = False
@@ -2191,8 +2204,37 @@ class Linker:
             added = True
             log.info(f"External sym '{symName}' @ {baseAddr}  len={lengthBytes}")
 
+            # "linkInfo": "placement" -- AN ADDRESS, NOT A DEFINITION.
+            #
+            # A CSECT table may carry a section this configuration does not
+            # load, and it must:  a configuration can hold a module's ZCON
+            # without holding the module, and the ZCON has to point at the
+            # address that code has in the configuration where the overlay IS
+            # loaded.  The section is still placed and its symbols are still
+            # DEFINED, so the symbol table this linker writes is unchanged --
+            # the AP-101S emulators read it and it is not ours to alter.
+            #
+            # What such an entry may not do is RESOLVE a relocation.  Its
+            # contents are fields inside a section no module supplied, so the
+            # original link had no definition for them and left the field
+            # zero.  In OI340600's GNC9, FIOPDSPG's `#LBR TFCMPFD1` and
+            # `#LBR TFCMPFD2` name two fields of #DDPLLIG, which that
+            # configuration does not contain -- DPLLIGHT is absent from its
+            # memory map where DG9LIGHT is present -- and the flight image
+            # holds 0000 in both.  Resolving them from the table produced 05C0
+            # and 05C4 instead.
+            #
+            # THE SECTION NAME ITSELF STILL RESOLVES.  Only the contents are
+            # withheld, because the case that needs the address is a ZCON
+            # pointing at an overlay, and that names the section rather than a
+            # field inside it.
+            #
+            # An entry without the field behaves exactly as before, so a table
+            # that does not use it is unaffected.
             contents = entry.get('contents')
             if contents:
+                if entry.get('linkInfo') == 'placement':
+                    self.placementOnlySymbols.update(contents)
                 for ldName, ldVal in contents.items():
                     if isinstance(ldVal, dict):
                         offsetHW = ldVal.get('offset', 0)

--- a/test/srcTest/lnk101/test_placement_only.py
+++ b/test/srcTest/lnk101/test_placement_only.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+#
+# `"linkInfo": "placement"` in a CSECT table: the entry contributes an
+# ADDRESS but not a DEFINITION.
+#
+# A CSECT table may deliberately carry a section the configuration does not
+# load -- see fcmcmp's load_not_in_config -- because a configuration can hold
+# a module's ZCON without holding the module.  Such an entry is still placed
+# and its symbols are still DEFINED, so the symbol table lnk101 writes is
+# unchanged; the AP-101S emulators read it.  What it may not do is RESOLVE a
+# relocation, because no module supplied the symbol and the original link left
+# the site alone.
+#
+# Run:  python -m pytest test/srcTest/lnk101/test_placement_only.py
+#  or:  python test/srcTest/lnk101/test_placement_only.py
+#
+import json
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
+
+from lnk101.linker import Linker
+
+
+def _args(**kw):
+    a = types.SimpleNamespace(link_order=None, force=False, strict_compools=False,
+                              base_address=0)
+    for k, v in kw.items():
+        setattr(a, k, v)
+    return a
+
+
+TABLE = {
+    "#DDG9LIG": {"start": 0x0500, "end": 0x0520,
+                 "contents": {"TFCMG9A": 4}},
+    "#DDPLLIG": {"start": 0x0500, "end": 0x0530,
+                 "linkInfo": "placement",
+                 "contents": {"TFCMPFD1": 30, "TFCMPFD2": 34}},
+}
+
+
+class TestPlacementOnly(unittest.TestCase):
+
+    def _load(self, table, undefined):
+        linker = Linker(_args())
+        for name in undefined:
+            linker.undefinedSymbols[name].add(("test.obj", None))
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            json.dump(table, f)
+            path = f.name
+        linker.loadExternalSyms(path)
+        Path(path).unlink()
+        return linker
+
+    def _defined(self, linker):
+        # LDs live in their own list, not in `sections` -- see addSection.
+        names = set()
+        for module in linker.modules:
+            names.update(s.name.strip() for s in module.sections.values())
+            names.update(s.name.strip() for s in module.lds)
+        return names
+
+    def test_placement_only_symbols_are_recorded(self):
+        linker = self._load(TABLE, ["TFCMPFD1"])
+        self.assertIn("TFCMPFD1", linker.placementOnlySymbols)
+        self.assertIn("TFCMPFD2", linker.placementOnlySymbols)
+
+    def test_ordinary_entry_contributes_nothing_to_the_set(self):
+        linker = self._load(TABLE, ["TFCMG9A"])
+        self.assertNotIn("TFCMG9A", linker.placementOnlySymbols)
+
+    def test_the_symbol_table_is_unchanged(self):
+        # The whole point: a placement-only entry is still placed and its
+        # contents still defined, so nothing disappears from the symbol table.
+        linker = self._load(TABLE, ["TFCMPFD1"])
+        defined = self._defined(linker)
+        self.assertIn("#DDPLLIG", defined)
+        self.assertIn("TFCMPFD1", defined)
+        self.assertIn("TFCMPFD2", defined)
+
+    def test_a_table_without_the_field_behaves_as_before(self):
+        plain = {k: {kk: vv for kk, vv in v.items() if kk != "linkInfo"}
+                 for k, v in TABLE.items()}
+        linker = self._load(plain, ["TFCMPFD1"])
+        self.assertEqual(linker.placementOnlySymbols, set())
+        self.assertIn("TFCMPFD1", self._defined(linker))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
*Filed under @rburkey2005's account, but written by Claude Code with Ron's review and approval — noted up front so the style doesn't come as a surprise.*

A CSECT table may deliberately carry a section the configuration does not load. `fcmcmp`'s `load_not_in_config` explains why: a configuration can hold a module's ZCON without holding the module, and the ZCON must point at the address that code has in the configuration where the overlay **is** loaded. So the section gets placed — and `--external-syms` also **defines** every field the entry lists.

Defining them makes this linker resolve references the original link could not. No module supplied the symbol, so the original had no definition and left the site alone. In OI340600's GNC9, `FIOPDSPG`'s

```
    #LBR TFCMPFD1
    #LBR TFCMPFD2
```

name two fields of `#DDPLLIG`, a section that configuration does not contain — `DPLLIGHT` is absent from its memory map where `DG9LIGHT` is present — and the flight image holds `0000` in both. Resolving them from the table produced `05C0` and `05C4` instead.

An entry marked

```json
    "linkInfo": "placement"
```

therefore contributes its address and not its linkage. The section is still placed and its contents are still defined — the symbol table this linker writes is unchanged, which matters because the AP-101S emulators read it — but those symbols never resolve a relocation. A reference to one is recorded in `unresolvedRelocations` and the site is left as the original left it.

The section **name** still resolves. Only the contents are withheld, because the case that needs the address is a ZCON pointing at an overlay, and that names the section rather than a field inside it.

An entry without the field behaves exactly as before, so a table that does not use it is unaffected — verified against OI340600's G9 table, where the link is byte-identical and `TFCMPFD1` resolves as it always did.

Four tests added.

### The mark comes from reference-site evidence, not from the memory map

At each site naming a field of the section, the dump either holds what resolution would have produced or holds an unpatched address field, and only the second is marked. A map-derived mark was tried first and is harmful: it helps two configurations and breaks the third, the same section going the other way each time. One section per configuration ends up marked — `#DDPLLIG` in G9, `#DDG9LIG` in S2, `#0ITOE` in SSW.

Measured over three configurations, same objects, tables differing only in this field:

| configuration | without the field | with it |
|---|---|---|
| G9 | 12 sections differ, 112 halfwords | **11 and 110** |
| S2 | 14 sections differ, 531 halfwords | **13 and 527** |
| SSW | 26 sections differ, 424 halfwords | 26 and 424 |

In both configurations that move, the section is `FIOPDSPG` and it goes to a match; nothing else changes anywhere. The symbol table is unchanged in all three — 3332, 2946 and 2238 symbols, identical with the field and without it.
