### PR TITLE
ibmobjdump: --normalize, a canonical form for comparing two objects

### DIFF
--- a/src/tools/objdump.py
+++ b/src/tools/objdump.py
@@ -36,8 +36,10 @@ def _rld_type(flags):
     return f"{con.kind}({'-' if con.is_negative else '+'})"
 
 
-def _print_sym_table(symbols):
-    """Print the decoded SYM symbol table."""
+def _sym_table_lines(symbols):
+    """The decoded SYM symbol table, as a list of lines."""
+    out = []
+    print = out.append  # noqa: A001 -- collect rather than emit
     print(f"{'=' * 60}")
     print(f"SYM table: {len(symbols)} symbols")
     print(f"{'=' * 60}")
@@ -62,13 +64,32 @@ def _print_sym_table(symbols):
             parts.append("CLUSTER")
         print("  ".join(parts))
     print(f"{'=' * 60}")
+    return out
 
 
-def dump_obj(filename, hex_dump=False, show_sym=False):
+def dump_obj(filename, hex_dump=False, show_sym=False, normalize=False):
     of = objModule.ObjectFile(str(filename))
 
+    # NORMALIZED OUTPUT EXISTS SO THAT TWO OBJECTS CAN BE COMPARED.  An
+    # assembler is free to emit its ESD entries in any order -- ASM101S keeps
+    # ENTRY and EXTRN symbols in Python sets, so the order varies from one run
+    # to the next, and assembling one module three times gave three different
+    # files with no difference in meaning.  Nothing else in the file is
+    # positional: TXT, RLD and END all name their section, and the ESD index is
+    # merely where the entry happened to land.  So dropping the index columns
+    # and sorting is lossless, and it turns "are these two objects the same
+    # program" back into a question `diff` can answer.
+    blocks = []  # (kind, sortKey, [lines]); kind orders the groups
+
+    def emit(lines, kind=3, key=""):
+        if normalize:
+            blocks.append((kind, key, lines))
+        else:
+            for line in lines:
+                print(line)
+
     for err in (e for m in of.modules for e in m.errors):
-        print(f"  {err}")
+        emit([f"  {err}"])
 
     symbols = [s for m in of.modules for s in m.symbols]
     esd_names = {}  # esdId -> name
@@ -79,33 +100,39 @@ def dump_obj(filename, hex_dump=False, show_sym=False):
 
         # Print SYM table after the last SYM card
         if show_sym and not sym_table_printed and typ != "SYM" and symbols:
-            _print_sym_table(symbols)
+            emit(_sym_table_lines(symbols))
             sym_table_printed = True
 
         if isinstance(rec, ControlRecord):
-            print(f"CTL  {rec.text.rstrip()}")
+            emit([f"CTL  {rec.text.rstrip()}"])
 
         elif isinstance(rec, EsdRecord):
             for e in rec.esdEntries:
                 name = e.name.strip()
                 esd_names[e.esdId] = name
 
-                parts = [f"ESD  [{e.esdId:3d}] {e.typeName:2s} {name:8s}"]
+                index = "     " if normalize else f"[{e.esdId:3d}] "
+                parts = [f"ESD  {index}{e.typeName:2s} {name:8s}"]
                 if e.address is not None:
                     parts.append(f"addr={Addr(e.address).x}")
                 if e.length is not None:
                     parts.append(f"len={AddrDisp(e.length).hw} hw")
                 if e.ldid is not None:
-                    parts.append(f"ldid={e.ldid}")
+                    # An LD cites the SD it belongs to by index, which moves
+                    # with the ESD order; its name does not.
+                    parts.append(f"ldid={esd_names.get(e.ldid, e.ldid)}"
+                                 if normalize else f"ldid={e.ldid}")
                 if e.remote:
                     parts.append("REMOTE")
-                print("  ".join(parts))
+                line = "  ".join(parts)
+                emit([line], kind=0, key=line)
 
         elif isinstance(rec, TxtRecord):
             tr = rec.textRecord
             size = len(tr.data)
             name = esd_names.get(tr.esdId, f"#{tr.esdId}")
-            print(f"TXT  [{tr.esdId:3d}] {name:8s}  addr={Addr(tr.address).x}  {size} bytes")
+            index = "     " if normalize else f"[{tr.esdId:3d}] "
+            lines = [f"TXT  {index}{name:8s}  addr={Addr(tr.address).x}  {size} bytes"]
             if hex_dump and size > 0:
                 for off in range(0, size, 16):
                     chunk = tr.data[off:min(off + 16, size)]
@@ -116,18 +143,20 @@ def dump_obj(filename, hex_dump=False, show_sym=False):
                             hwords.append(f"{chunk[h]:02X}{chunk[h+1]:02X}")
                         else:
                             hwords.append(f"{chunk[h]:02X}")
-                    print(f"       {Addr(tr.address + off).x}: {' '.join(hwords)}")
+                    lines.append(f"       {Addr(tr.address + off).x}: {' '.join(hwords)}")
+            emit(lines, kind=1, key=f"{name} {tr.address:08X}")
 
         elif isinstance(rec, RldRecord):
             for r in RldEntry.expand([rec.payload], []):
                 rname = esd_names.get(r.relId, f"#{r.relId}")
                 pname = esd_names.get(r.posId, f"#{r.posId}")
                 rtype = _rld_type(r.flags)
-                print(f"RLD  {rtype:12s}  {rname:8s} -> {pname:8s}"
-                      f"  addr={Addr(r.address).x}  flags={r.flags:02X}")
+                line = (f"RLD  {rtype:12s}  {rname:8s} -> {pname:8s}"
+                        f"  addr={Addr(r.address).x}  flags={r.flags:02X}")
+                emit([line], kind=2, key=line)
 
         elif isinstance(rec, SymRecord):
-            print(f"SYM  {rec.numBytesData} bytes")
+            emit([f"SYM  {rec.numBytesData} bytes"])
 
         elif isinstance(rec, EndRecord):
             end = rec.endInfo
@@ -138,17 +167,25 @@ def dump_obj(filename, hex_dump=False, show_sym=False):
                 parts.append(f"entryName={end.entryName.strip()}")
             if end.esdId is not None:
                 name = esd_names.get(end.esdId, f"#{end.esdId}")
-                parts.append(f"esdid={end.esdId}({name})")
+                parts.append(f"esdid={name}" if normalize
+                             else f"esdid={end.esdId}({name})")
             if end.length is not None:
                 parts.append(f"len={end.length}")
             if end.translator and end.translator.strip():
                 parts.append(f"translator={end.translator.strip()}")
             if end.processor and end.processor.strip():
                 parts.append(f"processor={end.processor.strip()}")
-            print("  ".join(parts))
+            emit(["  ".join(parts)])
 
         else:
-            print(f"???  type={typ}")
+            emit([f"???  type={typ}"])
+
+    if normalize:
+        # Stable sort, so the groups that are NOT reordered -- CTL, SYM, END --
+        # keep the order they were read in.
+        for _, _, lines in sorted(blocks, key=lambda b: (b[0], b[1])):
+            for line in lines:
+                print(line)
 
 
 def extract_txt(filename, out_dir):
@@ -197,6 +234,11 @@ def main(
         help="Include hex dump of TXT record data")] = False,
     show_sym: Annotated[bool, typer.Option("--show-sym-table", "-s",
         help="Show decoded SYM symbol table")] = False,
+    normalize: Annotated[bool, typer.Option("--normalize", "-n",
+        help="Canonical form for comparing two objects: drop the ESD index "
+             "columns, which are positional, and sort the ESD, TXT and RLD "
+             "groups.  Implies --hex, since a comparison that ignored the "
+             "code would call two unrelated modules equal.")] = False,
     extract: Annotated[Optional[Path], typer.Option("--extract-txt",
         help="Extract each CSECT's TXT data to a .bin file in this directory"
     )] = None,
@@ -221,7 +263,8 @@ def main(
         if extract is not None:
             extract_txt(obj_file, extract)
         else:
-            dump_obj(obj_file, hex_dump=hex_dump, show_sym=show_sym)
+            dump_obj(obj_file, hex_dump=hex_dump or normalize,
+                     show_sym=show_sym, normalize=normalize)
 
     if repro:
         tracker.print_summary()

--- a/test/test_objdump_normalize.py
+++ b/test/test_objdump_normalize.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+#
+# ibmobjdump --normalize: the canonical form used to compare two object files.
+#
+# WHY THE SWITCH EXISTS.  An assembler may emit its ESD entries in any order.
+# ASM101S keeps ENTRY and EXTRN symbols in Python sets, so the order varies
+# from run to run: assembling one module three times produced three different
+# files, 411 of 3280 bytes moving, with no difference in meaning.  Comparing
+# such objects byte-for-byte answers the wrong question.  Nothing else in the
+# file is positional -- TXT, RLD and END all name their section -- so dropping
+# the ESD index columns and sorting is lossless.
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+SRC = HERE.parent / "src"
+FIXTURE = HERE / "asm101" / "golden" / "scal_with_base_emits_rld.obj"
+
+
+def dump(*args):
+    r = subprocess.run(
+        [sys.executable, "-m", "tools.objdump", "--no-repro", *args, str(FIXTURE)],
+        capture_output=True, text=True, cwd=str(SRC), timeout=120)
+    assert r.returncode == 0, r.stderr
+    return r.stdout.splitlines()
+
+
+@pytest.mark.skipif(not FIXTURE.exists(), reason="fixture object not present")
+def test_normalize_drops_the_positional_columns():
+    """The ESD index is where an entry landed, not part of what it says."""
+    for line in dump("--normalize"):
+        if line.startswith(("ESD", "TXT")):
+            assert not re.match(r"^(ESD|TXT)\s+\[\s*\d+\]", line), line
+
+
+@pytest.mark.skipif(not FIXTURE.exists(), reason="fixture object not present")
+def test_normalize_sorts_the_esd():
+    esd = [l for l in dump("--normalize") if l.startswith("ESD")]
+    assert esd == sorted(esd)
+
+
+@pytest.mark.skipif(not FIXTURE.exists(), reason="fixture object not present")
+def test_normalize_implies_hex():
+    """A comparison that ignored the code would call two unrelated modules
+    equal, so --normalize turns the hex dump on whether or not -x was given."""
+    hexLine = re.compile(r"^\s+[0-9A-F]+:\s+[0-9A-F]{4}")
+    assert any(hexLine.match(l) for l in dump("--normalize"))
+    assert not any(hexLine.match(l) for l in dump())
+
+
+@pytest.mark.skipif(not FIXTURE.exists(), reason="fixture object not present")
+def test_default_output_is_unaffected():
+    """The switch must not change what everyone else already reads."""
+    assert dump() == dump("--no-repro")
+
+
+@pytest.mark.skipif(not FIXTURE.exists(), reason="fixture object not present")
+def test_normalize_still_reports_every_record():
+    """Sorting groups records; it must not drop any."""
+    plain = dump("--hex")
+    norm = dump("--normalize")
+    for kind in ("ESD", "TXT", "RLD", "END"):
+        assert (len([l for l in plain if l.startswith(kind)])
+                == len([l for l in norm if l.startswith(kind)])), kind


### PR DESCRIPTION
*Filed under @rburkey2005's account, but written by Claude Code with Ron's review and approval — noted up front so the style doesn't come as a surprise.*

An assembler is free to emit its ESD entries in any order, and ASM101S does. It keeps `ENTRY` and `EXTRN` symbols in Python sets, so the order varies from process to process. One AP-101S module assembled **three times by the same unmodified assembler** produced three different files, 411 of its 3280 bytes moving, with no difference in meaning. Comparing two objects byte-for-byte therefore answers the wrong question, and there was no way to ask the right one.

Nothing else in the file is positional. `TXT`, `RLD` and `END` all name their section rather than citing an ESD index, so those index columns are the only thing an ordering can move — dropping them and sorting is lossless.

`--normalize` does that:

- no `[  N]` on `ESD` or `TXT` lines
- an LD's `ldid=` and `END`'s `esdid=` rendered by **name** instead of index
- the `ESD`, `TXT` and `RLD` groups sorted, each `TXT` line keeping its own hex lines with it
- the sort is stable, so `CTL`, `SYM` and `END` stay in the order they were read

It implies `--hex`. Without the data a `TXT` line carries only a byte count, and two objects with entirely different code would compare equal — the one failure a comparison tool must not have.

Default output is unchanged, byte for byte.

### Validated in both directions

| | raw bytes | `--normalize` |
|---|---|---|
| same module, two runs (ordering only) | differ, 411 of 3280 bytes | **identical** |
| same module, different fill byte (real change) | differ | **differs**, at `000A8: C7E1 0000` vs `C7E1 C6C6` |

The second row is the one that matters: normalizing must not make a real difference disappear.

### Tests

Five, covering the flag's contract: the positional columns do not survive, the ESD comes out sorted, `--normalize` turns the hex on where plain output leaves it off, default output is unaffected, and the per-type record counts are preserved so sorting cannot silently drop a record.

`16 failed, 48 passed, 9 skipped` → `16 failed, 53 passed, 9 skipped`. The 16 are pre-existing on `master` in my checkout (`test/fcmcmp/`, unrelated to objdump), and `test_dfg_decks.py` / `test_mcconfigs.py` were skipped because they need a `code/OI340600/CON80` directory I don't have.
