### PR TITLE
con80build: recognize PCHnnSRC patch decks whether or not .asm-suffixed

### DIFF
--- a/src/con80/con80build.py
+++ b/src/con80/con80build.py
@@ -111,13 +111,21 @@ _RUNTIME_RE = re.compile(r"^(#?[QZ]|#?L|#?0|\$0|\$Y|\$X|#Y|#T)")
 # Patch-area decks: a source PCHnnSRC (SSSRC) is assembled to an object
 # whose CON80 object-library member name is PCHnnTXT -- the deck pulls it in
 # with INCLUDE SYSLIBL1(PCHnnTXT) and then INSERTs the csects it defines.
+# The source filename may or may not carry its .asm extension (both OI301700
+# and, since 00d1051b, OI340600 have it; ASM101S requires it), so every match
+# against a patch-deck filename goes through _src_stem() first.
 _PATCH_SRC_RE = re.compile(r"^PCH\d+SRC$")
 _PATCH_MEMBER_RE = re.compile(r"^PCH\d+TXT$")
 
 
+def _src_stem(name: str) -> str:
+    """Filename with a trailing .asm extension removed, if it has one."""
+    return name[:-4] if name.lower().endswith(".asm") else name
+
+
 def patch_member(src_name: str) -> str:
-    """PCHnnSRC source filename -> PCHnnTXT object-library member name."""
-    return src_name[:-3] + "TXT"
+    """PCHnnSRC[.asm] source filename -> PCHnnTXT object-library member name."""
+    return _src_stem(src_name)[:-3] + "TXT"
 
 
 # An IS-macro invocation in a patch deck: <label> IS <len>,<prefix>,<fill>.
@@ -162,6 +170,13 @@ class SourceIndex:
                 if not p.is_file():
                     continue
                 self.by_name.setdefault(p.name, p)
+                # A patch deck's PCHnnSRC[.asm] name is looked up by its
+                # extensionless stem (via patch_member()/resolve() below),
+                # never by the bare filename with extension -- index that
+                # stem too, so a .asm-suffixed patch source still resolves.
+                stem = _src_stem(p.name)
+                if stem != p.name and _PATCH_SRC_RE.match(stem):
+                    self.by_name.setdefault(stem, p)
                 self.by_stem6.setdefault(p.name[:6], p)
                 # Some source filenames embed a '#' that is NOT part of the
                 # 6-char stem encoded in the csect name (e.g. the file
@@ -314,7 +329,7 @@ def included_csects(graph, src: SourceIndex) -> dict:
             continue
         # Patch decks define their csects through the IS macro, so the generic
         # CSECT/ENTRY scan finds nothing -- derive the names from the IS lines.
-        if _PATCH_SRC_RE.match(f.name):
+        if _PATCH_SRC_RE.match(_src_stem(f.name)):
             for nm in patch_csects(f):
                 provided.setdefault(nm, f)
             continue
@@ -338,7 +353,7 @@ def patch_index(src: SourceIndex) -> dict[str, Path]:
         if not sub.is_dir():
             continue
         for p in sorted(sub.iterdir()):
-            if p.is_file() and _PATCH_SRC_RE.match(p.name):
+            if p.is_file() and _PATCH_SRC_RE.match(_src_stem(p.name)):
                 for nm in patch_csects(p):
                     idx.setdefault(nm, p)
     return idx
@@ -378,7 +393,7 @@ def resolve_worklist(deck_dir: Path, root: str, src: SourceIndex,
         # filename-stem heuristic (which conflates split-source csects like
         # #DDCICYC -> DCI#DATA with the code file DCICYC).
         path = csect_defs.get(m) or src.resolve(m) or provided.get(m)
-        if path is not None and _PATCH_SRC_RE.match(path.name):
+        if path is not None and _PATCH_SRC_RE.match(_src_stem(path.name)):
             patches.setdefault(path, patch_member(path.name))
             continue
         if path is None:

--- a/src/con80/con80build.py
+++ b/src/con80/con80build.py
@@ -170,21 +170,25 @@ class SourceIndex:
                 if not p.is_file():
                     continue
                 self.by_name.setdefault(p.name, p)
-                # A patch deck's PCHnnSRC[.asm] name is looked up by its
-                # extensionless stem (via patch_member()/resolve() below),
-                # never by the bare filename with extension -- index that
-                # stem too, so a .asm-suffixed patch source still resolves.
+                # Object-module/csect names (INCLUDE members, patch decks'
+                # PCHnnTXT -> PCHnnSRC[.asm]) are always looked up without a
+                # .asm extension -- index each file's extensionless stem too,
+                # so a .asm-suffixed source still resolves by its bare name.
+                # For a stem longer than 6 characters this is a no-op below
+                # (by_stem6 only ever looks at the first 6), but a <=6-char
+                # stem like FAZ2 would otherwise have its 6-char window bleed
+                # into ".asm" (FAZ2.asm[:6] == "FAZ2.a", not "FAZ2").
                 stem = _src_stem(p.name)
-                if stem != p.name and _PATCH_SRC_RE.match(stem):
+                if stem != p.name:
                     self.by_name.setdefault(stem, p)
-                self.by_stem6.setdefault(p.name[:6], p)
+                self.by_stem6.setdefault(stem[:6], p)
                 # Some source filenames embed a '#' that is NOT part of the
                 # 6-char stem encoded in the csect name (e.g. the file
                 # DCI#STK backs csect #DDCISTK -> stem DCISTK).
                 # Index a '#'-stripped stem too so those resolve; setdefault
                 # keeps an exact-named file's claim on the key.
-                stripped = p.name.replace("#", "")[:6]
-                if stripped != p.name[:6]:
+                stripped = stem.replace("#", "")[:6]
+                if stripped != stem[:6]:
                     self.by_stem6.setdefault(stripped, p)
 
     def resolve(self, module: str) -> Path | None:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -355,6 +355,19 @@ set_tests_properties(con80_patch_decks PROPERTIES
     TIMEOUT 60
 )
 
+# con80.con80build.SourceIndex.resolve() for a <=6-char-stem source file
+# (e.g. SSSRC/FAZ2.asm) whose own CSECT differs from its filename -- the
+# file is found only by its own name, and a .asm extension used to bleed
+# into the 6-char stem window.
+add_test(NAME con80_source_index
+    COMMAND "${SDL_VENV_PYTHON}"
+        "${CMAKE_CURRENT_SOURCE_DIR}/test_con80_source_index.py"
+)
+set_tests_properties(con80_source_index PROPERTIES
+    LABELS "ap101Utils"
+    TIMEOUT 60
+)
+
 add_test(NAME dfg_decks
     COMMAND "${SDL_VENV_PYTHON}"
         "${CMAKE_CURRENT_SOURCE_DIR}/test_dfg_decks.py"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -343,6 +343,18 @@ set_tests_properties(con80_mirror PROPERTIES
     TIMEOUT 60
 )
 
+# con80.con80build patch-deck (PCHnnSRC/PCHnnTXT) detection: must recognize
+# a patch source's PCHnnSRC filename whether or not it carries a trailing
+# .asm extension -- both spellings appear across the OI30/OI34 corpora.
+add_test(NAME con80_patch_decks
+    COMMAND "${SDL_VENV_PYTHON}"
+        "${CMAKE_CURRENT_SOURCE_DIR}/test_con80_patch_decks.py"
+)
+set_tests_properties(con80_patch_decks PROPERTIES
+    LABELS "ap101Utils"
+    TIMEOUT 60
+)
+
 add_test(NAME dfg_decks
     COMMAND "${SDL_VENV_PYTHON}"
         "${CMAKE_CURRENT_SOURCE_DIR}/test_dfg_decks.py"

--- a/test/test_con80_patch_decks.py
+++ b/test/test_con80_patch_decks.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""con80build patch-deck (PCHnnSRC/PCHnnTXT) detection.
+
+A patch deck's source filename may or may not carry a trailing .asm
+extension -- OI301700 has always shipped PCHnnSRC.asm, and OI340600's
+own PCHnnSRC files gained the extension in 00d1051b (they are ordinary
+AP-101S assembly and ASM101S/ASM101Sa refuse to assemble a source file
+whose name doesn't end in .asm).  patch_member()/SourceIndex.resolve()/
+patch_index()/included_csects()/resolve_worklist() all key off the
+PCHnnSRC/PCHnnTXT filename shape and must recognize it regardless of
+which spelling is on disk -- confirmed here for both.
+"""
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent / "src"))
+
+from con80.con80build import SourceIndex, patch_csects, patch_index, patch_member
+
+_failures = []
+_passes = 0
+
+
+def check(name, cond, detail=""):
+  global _passes
+  if cond:
+    _passes += 1
+  else:
+    _failures.append((name, detail))
+    print(f"FAIL {name}: {detail}")
+
+
+def test_patch_member_naming():
+  check("bare stem", patch_member("PCH10SRC") == "PCH10TXT",
+        patch_member("PCH10SRC"))
+  check(".asm-suffixed", patch_member("PCH10SRC.asm") == "PCH10TXT",
+        patch_member("PCH10SRC.asm"))
+  check(".asm suffix is case-insensitive",
+        patch_member("PCH10SRC.ASM") == "PCH10TXT",
+        patch_member("PCH10SRC.ASM"))
+
+
+def _patch_deck(prefix: str) -> str:
+  return f"001      IS    1F4,{prefix},C6C6\n         END\n"
+
+
+def _write_deck(sssrc: Path, name: str, prefix: str):
+  (sssrc / name).write_text(_patch_deck(prefix))
+
+
+def test_source_index_and_patch_index():
+  with tempfile.TemporaryDirectory() as td:
+    root = Path(td)
+    sssrc = root / "SSSRC"
+    sssrc.mkdir()
+    _write_deck(sssrc, "PCH10SRC.asm", "#Y101")   # current on-disk spelling
+    _write_deck(sssrc, "PCH11SRC", "#Y111")       # legacy extensionless spelling
+
+    src = SourceIndex([sssrc])
+
+    check("resolve PCH10TXT -> PCH10SRC.asm",
+          src.resolve("PCH10TXT") == sssrc / "PCH10SRC.asm",
+          src.resolve("PCH10TXT"))
+    check("resolve PCH11TXT -> PCH11SRC",
+          src.resolve("PCH11TXT") == sssrc / "PCH11SRC",
+          src.resolve("PCH11TXT"))
+
+    idx = patch_index(src)
+    check("patch_index sees both decks", len(idx) == 2, idx)
+    check("patch_index: #Y101001 -> PCH10SRC.asm",
+          idx.get("#Y101001") == sssrc / "PCH10SRC.asm", idx)
+    check("patch_index: #Y111001 -> PCH11SRC",
+          idx.get("#Y111001") == sssrc / "PCH11SRC", idx)
+
+
+def test_patch_csects_unaffected_by_extension():
+  with tempfile.TemporaryDirectory() as td:
+    root = Path(td)
+    sssrc = root / "SSSRC"
+    sssrc.mkdir()
+    _write_deck(sssrc, "PCH12SRC.asm", "#Y121")
+    check("patch_csects reads the IS line regardless of filename",
+          patch_csects(sssrc / "PCH12SRC.asm") == ["#Y121001"],
+          patch_csects(sssrc / "PCH12SRC.asm"))
+
+
+def main():
+  test_patch_member_naming()
+  test_source_index_and_patch_index()
+  test_patch_csects_unaffected_by_extension()
+  print(f"{_passes} passed, {len(_failures)} failed")
+  return 1 if _failures else 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/test/test_con80_source_index.py
+++ b/test/test_con80_source_index.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""con80build SourceIndex.resolve() for short (<=6-char) filenames.
+
+An object-module/csect name that con80build looks up (an INCLUDE
+member, a bare csect reference) never carries a .asm extension, but
+every source file on disk does.  For a filename longer than 6
+characters this is a non-issue: by_stem6's 6-char window never reaches
+the extension.  But for a filename whose extensionless stem is 6
+characters or shorter -- e.g. SSSRC/FAZ2.asm, whose own CSECT is
+PHAS2, so it is found only via its filename, through the INCLUDE
+SYSLIBL1(...,FAZ2,...) member name -- the window used to bleed into
+the extension: FAZ2.asm[:6] == "FAZ2.a", not "FAZ2", so resolve("FAZ2")
+returned None and con80build reported FAZ2 unresolved (PHASE10) even
+though its CSECT (PHAS2) linked in fine via the independent
+csect_defs() scan.  by_name/by_stem6 now index every file under its
+extensionless stem, not just its on-disk name.
+"""
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent / "src"))
+
+from con80.con80build import SourceIndex, included_csects
+
+_failures = []
+_passes = 0
+
+
+def check(name, cond, detail=""):
+  global _passes
+  if cond:
+    _passes += 1
+  else:
+    _failures.append((name, detail))
+    print(f"FAIL {name}: {detail}")
+
+
+class _FakeGraph:
+  """Just enough of concard.Graph for included_csects()."""
+  def __init__(self, members):
+    self._members = members
+
+  def library_members(self):
+    return self._members
+
+
+def test_short_stem_resolves_despite_asm_extension():
+  with tempfile.TemporaryDirectory() as td:
+    root = Path(td)
+    sssrc = root / "SSSRC"
+    sssrc.mkdir()
+    # Mirrors SSSRC/FAZ2.asm: a 4-char stem whose own CSECT (PHAS2) is a
+    # different name than the file -- the file is only ever looked up by
+    # its own filename, via an INCLUDE member reference.
+    (sssrc / "FAZ2.asm").write_text("PHAS2    CSECT\n         END\n")
+    # A long-named file's [:6] window is unaffected either way -- sanity
+    # check that the general fix didn't disturb that existing behavior.
+    (sssrc / "BILDNEW5.asm").write_text("BILDNEW5 CSECT\n         END\n")
+
+    src = SourceIndex([sssrc])
+
+    check("resolve('FAZ2') finds FAZ2.asm by its own filename",
+          src.resolve("FAZ2") == sssrc / "FAZ2.asm", src.resolve("FAZ2"))
+    check("stem6 lookup for a short name also resolves",
+          src.by_stem6.get("FAZ2") == sssrc / "FAZ2.asm",
+          src.by_stem6.get("FAZ2"))
+    check("a long name's 6-char stem is untouched by the extension",
+          src.by_stem6.get("BILDNE") == sssrc / "BILDNEW5.asm",
+          src.by_stem6.get("BILDNE"))
+
+    # The real bug: included_csects() uses resolve("FAZ2") to open the
+    # file and harvest the csects it defines (PHAS2), for an INSERT PHAS2
+    # elsewhere in the deck to find.
+    graph = _FakeGraph(["FAZ2"])
+    provided = included_csects(graph, src)
+    check("included_csects() maps PHAS2 -> FAZ2.asm via the FAZ2 member name",
+          provided.get("PHAS2") == sssrc / "FAZ2.asm", provided)
+
+
+def main():
+  test_short_stem_resolves_despite_asm_extension()
+  print(f"{_passes} passed, {len(_failures)} failed")
+  return 1 if _failures else 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())


### PR DESCRIPTION
## Summary
- `con80build.py`'s patch-deck detection (`_PATCH_SRC_RE`/`_PATCH_MEMBER_RE`, and every callsite using them in `SourceIndex`, `included_csects()`, `patch_index()`, and `resolve_worklist()`) matched a `PCHnnSRC` filename exactly, with no extension.
- OI301700's `PCHnnSRC` files have always carried a `.asm` extension; OI340600's did not until they were renamed to add it, since `ASM101S`/`ASM101Sa` refuse to assemble a source file whose name doesn't end in `.asm`.
- Either way, the exact-match regex fails on the `.asm`-suffixed name: the patch decks silently vanish from `patch_index()`/`SourceIndex.resolve()`, and each csect a patch deck defines (e.g. Phase 10's `#Y101001`) falls through to the runtime-name heuristic instead of being routed to assembly -- so the patch area it reserves is missing from the linked image, with no error.
- Fixed by stripping a trailing `.asm` before every one of those matches (`_src_stem()`), and indexing patch-deck files under their extensionless stem in `SourceIndex.by_name` as well as their real name.
- A second commit generalizes the same fix: `SourceIndex.by_name`/`by_stem6` indexed every file under its bare on-disk name/6-char prefix, extension included. For a filename over 6 characters that's a no-op, but a filename whose extensionless stem is 6 characters or shorter had its `.asm` extension bleed into the 6-char window (`FAZ2.asm[:6] == "FAZ2.a"`, not `"FAZ2"`). `SSSRC/FAZ2.asm`'s own CSECT is `PHAS2`, a different name, so it's found only by its filename via PHASE10's `INCLUDE SYSLIBL1(...,FAZ2,...)` -- `resolve("FAZ2")` returned `None`, and `--plan` reported `FAZ2` unresolved (harmlessly, since the independent full-corpus CSECT scan found `PHAS2` regardless of which file provides it, but the report was wrong). Both `by_name` and `by_stem6` now also index every file under its extensionless stem; checked for stem collisions across OI340600 and OI301700's `SSSRC`+`APPLSRC` -- none.
- Added `test/test_con80_patch_decks.py` (`con80_patch_decks`) and `test/test_con80_source_index.py` (`con80_source_index`). No prior test exercised either code path.

## Note
The PFS archive has been updated with the modified filenames and must be re-downloaded.

## Test plan
- [x] `ctest -R con80` -- `con80_halorder`, `con80_mirror`, `con80_patch_decks`, `con80_source_index` all pass
- [x] `patch_index()` against the current OI340600 `SSSRC`/`APPLSRC` tree: 0 patch decks found before the fix, 184 after
- [x] PHASE10 rebuilt end-to-end (`--assemble --link`, current OI340600 tree) is byte-identical to the last known-good build made before the extension rename -- same `.fcm` md5, same `.obj` md5s for all 12 linked inputs, `0 unresolved` (was `FAZ2` before the second commit, `PCH10TXT`/`FAZ2` both before the first)